### PR TITLE
resolve null profile property on newly registered user

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App;
+use App\Models\Profile;
 use App\Models\User;
 use App\Traits\CaptchaTrait;
 use App\Traits\CaptureIpTrait;

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -103,6 +103,7 @@ class RegisterController extends Controller
 
         $ipAddress  = new CaptureIpTrait;
         $role       = Role::where('name', '=', 'Unverified')->first();
+        $profile    = new Profile;
 
         $user =  User::create([
             'name'              => $data['name'],
@@ -115,6 +116,7 @@ class RegisterController extends Controller
             'activated'         => !config('settings.activation')
         ]);
 
+        $user->profile()->save($profile);
         $user->attachRole($role);
         $this->initiateEmailActivation($user);
 


### PR DESCRIPTION
I'm wondering if this is even an issue or I just messed up something.

I see that `profile` property isn't being instantiated in `RegisterController@create`, is this intentional?

Because new users registered using email (non-socialite) get a null property error in views that are accessing `Auth::user()->profile->...`